### PR TITLE
  Added snippet for React.render and removed snippt for React.renderComponent

### DIFF
--- a/snippets/js-mode/rc.yasnippet
+++ b/snippets/js-mode/rc.yasnippet
@@ -1,8 +1,0 @@
-# -*- mode: snippet -*-
-# name: React.renderComponent
-# key: rc
-# --
-React.renderComponent(
-$1,
-$0
-);

--- a/snippets/js-mode/rr.yasnippet
+++ b/snippets/js-mode/rr.yasnippet
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: React.render
+# key: rr
+# --
+React.render(
+$1,
+$0
+);


### PR DESCRIPTION
- React.renderComponent is deprecated in favor of React.render.
- https://facebook.github.io/react/blog/2014/10/28/react-v0.12.html
