### PR TITLE
indent the "bodies" where appropriate

### DIFF
--- a/snippets/js-mode/cc.yasnippet
+++ b/snippets/js-mode/cc.yasnippet
@@ -3,5 +3,5 @@
 # key: cc
 # --
 React.createClass({
-$0
+  $0
 });

--- a/snippets/js-mode/cdm.yasnippet
+++ b/snippets/js-mode/cdm.yasnippet
@@ -3,5 +3,5 @@
 # key: cdm
 # --
 componentDidMount: function(${1:rootNode}) {
-$0
+  $0
 }

--- a/snippets/js-mode/cdu.yasnippet
+++ b/snippets/js-mode/cdu.yasnippet
@@ -3,5 +3,5 @@
 # key: cdu
 # --
 componentDidUpdate: function(${1:prevProps}, ${2:prevState}, ${3:rootNode}) {
-$0
+  $0
 }

--- a/snippets/js-mode/cwm.yasnippet
+++ b/snippets/js-mode/cwm.yasnippet
@@ -3,5 +3,5 @@
 # key: cwm
 # --
 componentWillMount: function() {
-$0
+  $0
 }

--- a/snippets/js-mode/cwrp.yasnippet
+++ b/snippets/js-mode/cwrp.yasnippet
@@ -3,5 +3,5 @@
 # key: cwrp
 # --
 componentWillReceiveProps: function(${1:nextProps}) {
-$0
+  $0
 }

--- a/snippets/js-mode/cwu.yasnippet
+++ b/snippets/js-mode/cwu.yasnippet
@@ -3,5 +3,5 @@
 # key: cwu
 # --
 componentWillUpdate: function(${1:nextProps}, ${2:nextState}) {
-$0
+  $0
 }

--- a/snippets/js-mode/cwum.yasnippet
+++ b/snippets/js-mode/cwum.yasnippet
@@ -3,5 +3,5 @@
 # key: cwum
 # --
 componentWillUnmount: function() {
-$0
+  $0
 }

--- a/snippets/js-mode/gdp.yasnippet
+++ b/snippets/js-mode/gdp.yasnippet
@@ -3,5 +3,5 @@
 # key: gdp
 # --
 getDefaultProps: function() {
-$0
+  $0
 }

--- a/snippets/js-mode/gis.yasnippet
+++ b/snippets/js-mode/gis.yasnippet
@@ -3,5 +3,5 @@
 # key: gis
 # --
 getInitialState: function() {
-$0
+  $0
 }

--- a/snippets/js-mode/r.yasnippet
+++ b/snippets/js-mode/r.yasnippet
@@ -3,5 +3,5 @@
 # key: r
 # --
 render: function() {
-$0
+  $0
 }

--- a/snippets/js-mode/rr.yasnippet
+++ b/snippets/js-mode/rr.yasnippet
@@ -3,6 +3,6 @@
 # key: rr
 # --
 React.render(
-$1,
-$0
+  $1,
+  $0
 );

--- a/snippets/js-mode/scu.yasnippet
+++ b/snippets/js-mode/scu.yasnippet
@@ -3,5 +3,5 @@
 # key: scu
 # --
 shouldComponentUpdate: function(${1:nextProps}, ${2:nextState}) {
-$0
+  $0
 }


### PR DESCRIPTION
Even though here we use 2 spaces, yasnippet will automatically indent
each line according to the mode, which takes into account any changes to
the indentation made by the user.

This wasn't happening previously presumably because the line was
considered "empty" and hence there was nothing to indent.

Now that the line is not empty, it will be properly indented.
